### PR TITLE
Fix `grunt serve` task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,7 +104,8 @@ module.exports = function (grunt) {
       serve: {
         options: {
           port: 9999,
-          dev: true
+          dev: true,
+          base: 'app'
         }
       }
     },


### PR DESCRIPTION
Add the base path (app) to nodestatic-serve task.
Before this, it was failing to find `require.js` when you visited
`http://localhost:9999/app`.

This change fixes that, but introduces a few other things:

- Now the homepage is the editor. (no more `/app`)
- No access to `/demo`
  - demo and app are the same thing right now, so it was basicaly
    duplicating things.
  - This doesn't remove the demo yet, but can be done if we think it's
    no loger needed.