### PR TITLE
Upgrade of, and adaption to D3 to version 4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.9.24",
   "dependencies": {
     "requirejs": "2.1.15",
-    "d3": "3.5.3",
+    "d3": "4.7.4",
     "requirejs-web-workers": "~1.0.1",
     "viz.js": "~1.5.1"
   },

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -202,7 +202,7 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
 
     function zoomed() {
       svg.select("g")
-        .attr('transform', 'translate(' + d3.event.translate + ') scale(' + d3.event.scale + ')');
+        .attr('transform', d3.event.transform);
     }
 
     return {
@@ -223,8 +223,7 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
 
         if (definition.zoom) {
           var extent = definition.zoom && definition.zoom.extent || [0.1, 10];
-          zoom = d3.behavior
-            .zoom()
+          zoom = d3.zoom()
             .scaleExtent(extent)
             .on("zoom", zoomed);
 
@@ -237,18 +236,17 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
       svg: function (reset) {
         if (reset) {
           var g = svg.select("g").select("g");
-          if (g[0]) {
-            zoom.scale(1);
-            zoom.translate([0, 0]);
+          if (g.node()) {
             g.attr("transform", "translate(0,0)scale(1)");
           }
         }
         return svg.node().parentNode.innerHTML;
       },
       setZoom: function (zoomParams) {
-        zoomParams.scale && zoom.scale(zoomParams.scale);
-        zoomParams.translate && zoom.translate(zoomParams.translate);
-        zoom.event(svg);
+        var g = svg.select("g");
+        var k = zoomParams.scale ? zoomParams.scale : d3.zoomTransform().k;
+        var [x, y] = zoomParams.translate ? zoomParams.translate : [d3.zoomTransform().x, d3.zoomTransform().y];
+        g.call(zoom.transform, d3.zoomIdentity.translate(x, y).scale(k));
       },
       transitions: function (custom) {
         if (custom) {

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -362,7 +362,8 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
           .data(function (d) {
             return d.labels;
           });
-        labels.enter().append("text");
+        labels = labels.enter().append("text")
+          .merge(labels);
         transitions.labels(labels, labelAttributer);
       },
       getImage: function (reset) {

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -348,7 +348,8 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
             return [d.shape, i].join('-');
           }
         );
-        shapes.enter().append("path");
+        shapes = shapes.enter().append("path")
+          .merge(shapes);
         transitions.shapes(shapes, function (selection) {
           selection
             .attr("d", function (d) {

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -298,7 +298,8 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
         }
         var label = main.selectAll("text")
           .data(stage.main.labels);
-        label.enter().append("text");
+        label = label.enter().append("text")
+          .merge(label);
         transitions.labels(label, labelAttributer);
 
         var groups = main.selectAll("g")

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -286,7 +286,7 @@ define('stage',["d3", "palette", "transitions/default", "styliseur"], function (
         });
 
         var overlay = svg.select("rect.overlay");
-        if (overlay[0]) {
+        if (overlay.node()) {
           transitions.canvas(overlay, function (selection) {
             selection
               .attr('width', sizes.width / sizes.scaleWidth)

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -54,8 +54,8 @@ define('palette',[],function () {
   };
 });
 define('styliseur',["d3"], function(d3) {
-  var styliseur = function () {
-    this.each(function (d) {
+  var styliseur = function (selection) {
+    selection.each(function (d) {
       var self = d3.select(this);
       var fillInsteadOfStroke = this instanceof SVGTextElement || false;
       d && d.style && d.style.forEach(function (e) {
@@ -184,8 +184,8 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
       };
     }
 
-    var labelAttributer = function () {
-      this
+    var labelAttributer = function (selection) {
+      selection
         .attr("x", function (d) {
           return d.x;
         })
@@ -261,8 +261,8 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
         var sizes = calculateSizes(stage.main);
         var area = [0, 0, sizes.width, sizes.height];
 
-        transitions.document(svg, function () {
-          this
+        transitions.document(svg, function (selection) {
+          selection
             .attr("width", sizes.width + "pt")
             .attr("height", sizes.height + "pt")
             .attr("viewBox", area.join(' '))
@@ -273,8 +273,8 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
         });
 
         var polygon = main.select("polygon").data(stage.main.shapes);
-        transitions.canvas(polygon, function () {
-          this
+        transitions.canvas(polygon, function (selection) {
+          selection
             .attr("points", function () {
               return [
                 [-sizes.margin, sizes.margin],
@@ -289,8 +289,8 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
 
         var overlay = svg.select("rect.overlay");
         if (overlay[0]) {
-          transitions.canvas(overlay, function () {
-            this
+          transitions.canvas(overlay, function (selection) {
+            selection
               .attr('width', sizes.width / sizes.scaleWidth)
               .attr('height', sizes.height / sizes.scaleHeight)
               .attr('y', -sizes.height / sizes.scaleHeight);
@@ -319,14 +319,14 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
           .attr("xlink:href", function(d) {return d.url;})
           .attr("xlink:title", function(d) {return d.tooltip;});
 
-        transitions.nodes(entering.filter(".node:empty,.node a"), function () {
-          this.style("opacity", 1.0);
+        transitions.nodes(entering.filter(".node:empty,.node a"), function (selection) {
+          selection.style("opacity", 1.0);
         });
-        transitions.relations(entering.filter(".relation"), function () {
-          this.style("opacity", 1.0);
+        transitions.relations(entering.filter(".relation"), function (selection) {
+          selection.style("opacity", 1.0);
         });
-        transitions.exits(groups.exit(), function () {
-          this.remove();
+        transitions.exits(groups.exit(), function (selection) {
+          selection.remove();
         });
 
         groups.sort(function (a, b) {
@@ -348,8 +348,8 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
           }
         );
         shapes.enter().append("path");
-        transitions.shapes(shapes, function () {
-          this
+        transitions.shapes(shapes, function (selection) {
+          selection
             .attr("d", function (d) {
               var shape = d.shape;
               return palette[shape](d);

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -146,7 +146,7 @@ define('transitions/default',["styliseur"], function(styliseur) {
     }
   };
 });
-define('stage',["d3", "palette", "transitions/default", "styliseur"], function (d3, palette, defaults, styliseur) {
+define('stage',["d3", "palette", "transitions/default"], function (d3, palette, defaults) {
     var svg, main, zoom;
     var order = {
       digraph: 0,
@@ -361,11 +361,10 @@ define('stage',["d3", "palette", "transitions/default", "styliseur"], function (
           .data(function (d) {
             return d.labels;
           });
-        transitions.labels(labels, labelAttributer);
-        labels.enter()
-          .append("text")
+        labels = labels.enter().append("text")
           .call(labelAttributer)
-          .call(styliseur);
+          .merge(labels);
+        transitions.labels(labels, labelAttributer);
       },
       getImage: function (reset) {
         reset = reset === undefined ? true : reset;

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -146,7 +146,7 @@ define('transitions/default',["styliseur"], function(styliseur) {
     }
   };
 });
-define('stage',["d3", "palette", "transitions/default"], function (d3, palette, defaults) {
+define('stage',["d3", "palette", "transitions/default", "styliseur"], function (d3, palette, defaults, styliseur) {
     var svg, main, zoom;
     var order = {
       digraph: 0,
@@ -361,9 +361,11 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
           .data(function (d) {
             return d.labels;
           });
-        labels = labels.enter().append("text")
-          .merge(labels);
         transitions.labels(labels, labelAttributer);
+        labels.enter()
+          .append("text")
+          .call(labelAttributer)
+          .call(styliseur);
       },
       getImage: function (reset) {
         reset = reset === undefined ? true : reset;

--- a/spec/stage-spec.js
+++ b/spec/stage-spec.js
@@ -111,7 +111,7 @@ define(["rfactory!stage", 'spec/shapes/directed/table'], function (stageFactory,
         expect(d3Spy.behavior.zoom.translate).toHaveBeenCalledWith(expected);
       });
 
-      it("should set zoom translate when only translate is provided", function () {
+      it("should set zoom translate and scale when both are provided", function () {
         var expectedTranslate = [12, 15];
         var expectedScale = 15;
         var zoom = {

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -1,4 +1,4 @@
-define(["d3", "palette", "transitions/default", "styliseur"], function (d3, palette, defaults, styliseur) {
+define(["d3", "palette", "transitions/default"], function (d3, palette, defaults) {
     var svg, main, zoom;
     var order = {
       digraph: 0,
@@ -213,11 +213,10 @@ define(["d3", "palette", "transitions/default", "styliseur"], function (d3, pale
           .data(function (d) {
             return d.labels;
           });
-        transitions.labels(labels, labelAttributer);
-        labels.enter()
-          .append("text")
+        labels = labels.enter().append("text")
           .call(labelAttributer)
-          .call(styliseur);
+          .merge(labels);
+        transitions.labels(labels, labelAttributer);
       },
       getImage: function (reset) {
         reset = reset === undefined ? true : reset;

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -150,7 +150,8 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
         }
         var label = main.selectAll("text")
           .data(stage.main.labels);
-        label.enter().append("text");
+        label = label.enter().append("text")
+          .merge(label);
         transitions.labels(label, labelAttributer);
 
         var groups = main.selectAll("g")

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -36,8 +36,8 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
       };
     }
 
-    var labelAttributer = function () {
-      this
+    var labelAttributer = function (selection) {
+      selection
         .attr("x", function (d) {
           return d.x;
         })
@@ -113,8 +113,8 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
         var sizes = calculateSizes(stage.main);
         var area = [0, 0, sizes.width, sizes.height];
 
-        transitions.document(svg, function () {
-          this
+        transitions.document(svg, function (selection) {
+          selection
             .attr("width", sizes.width + "pt")
             .attr("height", sizes.height + "pt")
             .attr("viewBox", area.join(' '))
@@ -125,8 +125,8 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
         });
 
         var polygon = main.select("polygon").data(stage.main.shapes);
-        transitions.canvas(polygon, function () {
-          this
+        transitions.canvas(polygon, function (selection) {
+          selection
             .attr("points", function () {
               return [
                 [-sizes.margin, sizes.margin],
@@ -141,8 +141,8 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
 
         var overlay = svg.select("rect.overlay");
         if (overlay[0]) {
-          transitions.canvas(overlay, function () {
-            this
+          transitions.canvas(overlay, function (selection) {
+            selection
               .attr('width', sizes.width / sizes.scaleWidth)
               .attr('height', sizes.height / sizes.scaleHeight)
               .attr('y', -sizes.height / sizes.scaleHeight);
@@ -171,14 +171,14 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
           .attr("xlink:href", function(d) {return d.url;})
           .attr("xlink:title", function(d) {return d.tooltip;});
 
-        transitions.nodes(entering.filter(".node:empty,.node a"), function () {
-          this.style("opacity", 1.0);
+        transitions.nodes(entering.filter(".node:empty,.node a"), function (selection) {
+          selection.style("opacity", 1.0);
         });
-        transitions.relations(entering.filter(".relation"), function () {
-          this.style("opacity", 1.0);
+        transitions.relations(entering.filter(".relation"), function (selection) {
+          selection.style("opacity", 1.0);
         });
-        transitions.exits(groups.exit(), function () {
-          this.remove();
+        transitions.exits(groups.exit(), function (selection) {
+          selection.remove();
         });
 
         groups.sort(function (a, b) {
@@ -200,8 +200,8 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
           }
         );
         shapes.enter().append("path");
-        transitions.shapes(shapes, function () {
-          this
+        transitions.shapes(shapes, function (selection) {
+          selection
             .attr("d", function (d) {
               var shape = d.shape;
               return palette[shape](d);

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -138,7 +138,7 @@ define(["d3", "palette", "transitions/default", "styliseur"], function (d3, pale
         });
 
         var overlay = svg.select("rect.overlay");
-        if (overlay[0]) {
+        if (overlay.node()) {
           transitions.canvas(overlay, function (selection) {
             selection
               .attr('width', sizes.width / sizes.scaleWidth)

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -214,7 +214,8 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
           .data(function (d) {
             return d.labels;
           });
-        labels.enter().append("text");
+        labels = labels.enter().append("text")
+          .merge(labels);
         transitions.labels(labels, labelAttributer);
       },
       getImage: function (reset) {

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -54,7 +54,7 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
 
     function zoomed() {
       svg.select("g")
-        .attr('transform', 'translate(' + d3.event.translate + ') scale(' + d3.event.scale + ')');
+        .attr('transform', d3.event.transform);
     }
 
     return {
@@ -75,8 +75,7 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
 
         if (definition.zoom) {
           var extent = definition.zoom && definition.zoom.extent || [0.1, 10];
-          zoom = d3.behavior
-            .zoom()
+          zoom = d3.zoom()
             .scaleExtent(extent)
             .on("zoom", zoomed);
 
@@ -89,18 +88,17 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
       svg: function (reset) {
         if (reset) {
           var g = svg.select("g").select("g");
-          if (g[0]) {
-            zoom.scale(1);
-            zoom.translate([0, 0]);
+          if (g.node()) {
             g.attr("transform", "translate(0,0)scale(1)");
           }
         }
         return svg.node().parentNode.innerHTML;
       },
       setZoom: function (zoomParams) {
-        zoomParams.scale && zoom.scale(zoomParams.scale);
-        zoomParams.translate && zoom.translate(zoomParams.translate);
-        zoom.event(svg);
+        var g = svg.select("g");
+        var k = zoomParams.scale ? zoomParams.scale : d3.zoomTransform().k;
+        var [x, y] = zoomParams.translate ? zoomParams.translate : [d3.zoomTransform().x, d3.zoomTransform().y];
+        g.call(zoom.transform, d3.zoomIdentity.translate(x, y).scale(k));
       },
       transitions: function (custom) {
         if (custom) {

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -200,7 +200,8 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
             return [d.shape, i].join('-');
           }
         );
-        shapes.enter().append("path");
+        shapes = shapes.enter().append("path")
+          .merge(shapes);
         transitions.shapes(shapes, function (selection) {
           selection
             .attr("d", function (d) {

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -1,4 +1,4 @@
-define(["d3", "palette", "transitions/default"], function (d3, palette, defaults) {
+define(["d3", "palette", "transitions/default", "styliseur"], function (d3, palette, defaults, styliseur) {
     var svg, main, zoom;
     var order = {
       digraph: 0,
@@ -213,9 +213,11 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
           .data(function (d) {
             return d.labels;
           });
-        labels = labels.enter().append("text")
-          .merge(labels);
         transitions.labels(labels, labelAttributer);
+        labels.enter()
+          .append("text")
+          .call(labelAttributer)
+          .call(styliseur);
       },
       getImage: function (reset) {
         reset = reset === undefined ? true : reset;

--- a/src/js/styliseur.js
+++ b/src/js/styliseur.js
@@ -1,6 +1,6 @@
 define(["d3"], function(d3) {
-  var styliseur = function () {
-    this.each(function (d) {
+  var styliseur = function (selection) {
+    selection.each(function (d) {
       var self = d3.select(this);
       var fillInsteadOfStroke = this instanceof SVGTextElement || false;
       d && d.style && d.style.forEach(function (e) {


### PR DESCRIPTION
You may want to have a look at the latest commit, 495567b4d3c3a1afe8ec80374831ecea15bb644b. I really don't understand why it is needed for labels (text), but not for shapes (path). The tests ran fine without it, but the initial transition was very funny, with shapes dropping down linearly from the top, but labels spreading of from the top left corner.

I've done a few manual checks with my local graphviz.it, but I would appreciate if you could also do some.
