### PR TITLE
Fixed panning when outzoomed by correcting zoom overlay

### DIFF
--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -227,10 +227,10 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
             .scaleExtent(extent)
             .on("zoom", zoomed);
 
-          svg.select("g")
-            .call(zoom)
+          svg
             .append("rect")
-            .attr("class", "overlay");
+            .attr("class", "overlay")
+            .call(zoom);
         }
       },
       svg: function (reset) {
@@ -290,8 +290,7 @@ define('stage',["d3", "palette", "transitions/default"], function (d3, palette, 
           transitions.canvas(overlay, function (selection) {
             selection
               .attr('width', sizes.width / sizes.scaleWidth)
-              .attr('height', sizes.height / sizes.scaleHeight)
-              .attr('y', -sizes.height / sizes.scaleHeight);
+              .attr('height', sizes.height / sizes.scaleHeight);
           });
         }
         var label = main.selectAll("text")

--- a/src/js/stage.js
+++ b/src/js/stage.js
@@ -79,10 +79,10 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
             .scaleExtent(extent)
             .on("zoom", zoomed);
 
-          svg.select("g")
-            .call(zoom)
+          svg
             .append("rect")
-            .attr("class", "overlay");
+            .attr("class", "overlay")
+            .call(zoom);
         }
       },
       svg: function (reset) {
@@ -142,8 +142,7 @@ define(["d3", "palette", "transitions/default"], function (d3, palette, defaults
           transitions.canvas(overlay, function (selection) {
             selection
               .attr('width', sizes.width / sizes.scaleWidth)
-              .attr('height', sizes.height / sizes.scaleHeight)
-              .attr('y', -sizes.height / sizes.scaleHeight);
+              .attr('height', sizes.height / sizes.scaleHeight);
           });
         }
         var label = main.selectAll("text")


### PR DESCRIPTION
From https://bl.ocks.org/mbostock/4e3925cdc804db257a86fdef3a032a45:

The zoom behavior is applied to an invisible rect overlaying the SVG
element; this ensures that it receives input, and that the pointer
coordinates are not affected by the zoom behavior’s transform.

There were several problems:

1. The overlay rect was a child of the g that was transformed.
2. The zoom behavior was not attached to the rect, but to the g.
3. The rect was not positioned correctly after applying fixes for 1
   and 2.